### PR TITLE
Fix event cover loading of next TD event

### DIFF
--- a/src/components/cards/TdCard.vue
+++ b/src/components/cards/TdCard.vue
@@ -171,7 +171,12 @@ export default {
       this.nextEvent = this.data[this.n]
 
       try {
-        let response = await fetch(this.eventCoverEndpoint)
+        let coverEndpointUrl = this.eventCoverEndpoint
+        if (!coverEndpointUrl) {
+          this.nextEventCover = undefined
+          return
+        }
+        let response = await fetch(coverEndpointUrl)
         let { cover } = await response.json()
         this.nextEventCover = cover.source
       } catch (e) {

--- a/src/components/cards/TdCard.vue
+++ b/src/components/cards/TdCard.vue
@@ -196,7 +196,7 @@ export default {
       this.poll()
     }, FB_TIMEOUT)
     this.timeout_event = setInterval(() => {
-      this.n = this.n >= this.data.length ? 0 : this.n + 1
+      this.n = (this.n + 1) >= this.data.length ? 0 : this.n + 1
       this.setNextEvent()
     }, 45000)
     this.timeout_countdown = setInterval(() => {


### PR DESCRIPTION
`this.eventCoverEndpoint` can return an empty string as shown in https://github.com/couven92/dust-webapp/blob/d6ad8d863a8605b4867cc1828ecf84d30da09ca7/src/components/cards/TdCard.vue#L79.

This messes up loading the event cover for the next event.

Returning an empty string might be caused by an incorrect index for the last event. This PR fixes an off-by-one-error which caused the app to access one element after the last item in the `data` array.