### PR TITLE
Remove obsolete dust cards from default dashboard

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -43,5 +43,5 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
-      artifactName: 'dist' 
+      artifactName: 'dist'
     continueOnError: true

--- a/src/router.js
+++ b/src/router.js
@@ -118,14 +118,14 @@ export default new Router({
       props: {
         queryProp: JSON.stringify({
           cards: [
-            {
-              name: 'dust-card',
-              thingId: '00001337'
-            },
-            {
-              name: 'dust-card',
-              thingId: '00001341'
-            },
+            // {
+            //   name: 'dust-card',
+            //   thingId: '00001337'
+            // },
+            // {
+            //   name: 'dust-card',
+            //   thingId: '00001341'
+            // },
             {
               name: 'airport-card',
               title: 'Tromsø Airport, Langnes',


### PR DESCRIPTION
IFI Dust sensors have been decommissioned. They should therefore be removed from the default dashboard. They will for future reference still be reachable through the `dust` path.