### PR TITLE
Change app base path to info

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -8,7 +8,7 @@ Vue.use(Router)
 
 export default new Router({
   mode: 'history',
-  base: '/dust',
+  base: '/info',
   routes: [
     {
       path: '/debug',

--- a/src/router.js
+++ b/src/router.js
@@ -127,15 +127,15 @@ export default new Router({
             //   thingId: '00001341'
             // },
             {
+              name: 'bus-card',
+              title: 'UiT (Southbound)',
+              from: '19021323:2'
+            },
+            {
               name: 'airport-card',
               title: 'Tromsø Airport, Langnes',
               center: '69.67,18.95',
               zoom: 7
-            },
-            {
-              name: 'bus-card',
-              title: 'UiT (Southbound)',
-              from: '19021323:2'
             },
             {
               name: 'bus-card',


### PR DESCRIPTION
Since the Dust sensors have been decommisioned, it is more sensical to let the app live in the `info` base path.